### PR TITLE
회원 도메인 기능 개발(#4)

### DIFF
--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/auth/adapter/in/web/SignupController.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/auth/adapter/in/web/SignupController.java
@@ -1,8 +1,8 @@
-package io.wisoft.avocadobackendhexagonal.domain.member.adapter.in.web;
+package io.wisoft.avocadobackendhexagonal.domain.auth.adapter.in.web;
 
-import io.wisoft.avocadobackendhexagonal.domain.member.adapter.in.web.dto.SignupRequest;
-import io.wisoft.avocadobackendhexagonal.domain.member.application.port.in.SignupUseCase;
-import io.wisoft.avocadobackendhexagonal.domain.member.application.port.in.command.SignupCommand;
+import io.wisoft.avocadobackendhexagonal.domain.auth.adapter.in.web.dto.SignupRequest;
+import io.wisoft.avocadobackendhexagonal.domain.auth.application.port.in.SignupUseCase;
+import io.wisoft.avocadobackendhexagonal.domain.auth.application.port.in.command.SignupCommand;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/auth/adapter/in/web/dto/SignupRequest.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/auth/adapter/in/web/dto/SignupRequest.java
@@ -1,8 +1,8 @@
-package io.wisoft.avocadobackendhexagonal.domain.member.application.port.in.command;
+package io.wisoft.avocadobackendhexagonal.domain.auth.adapter.in.web.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record SignupCommand(
+public record SignupRequest(
         @NotBlank String email,
         @NotBlank String password
 ) {

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/auth/application/port/in/SignupUseCase.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/auth/application/port/in/SignupUseCase.java
@@ -1,0 +1,8 @@
+package io.wisoft.avocadobackendhexagonal.domain.auth.application.port.in;
+
+import io.wisoft.avocadobackendhexagonal.domain.auth.application.port.in.command.SignupCommand;
+
+public interface SignupUseCase {
+
+    Long signup(final SignupCommand request);
+}

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/auth/application/port/in/command/SignupCommand.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/auth/application/port/in/command/SignupCommand.java
@@ -1,8 +1,8 @@
-package io.wisoft.avocadobackendhexagonal.domain.member.adapter.in.web.dto;
+package io.wisoft.avocadobackendhexagonal.domain.auth.application.port.in.command;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record SignupRequest(
+public record SignupCommand(
         @NotBlank String email,
         @NotBlank String password
 ) {

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/auth/application/port/out/SignUpPort.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/auth/application/port/out/SignUpPort.java
@@ -1,4 +1,4 @@
-package io.wisoft.avocadobackendhexagonal.domain.member.application.port.out;
+package io.wisoft.avocadobackendhexagonal.domain.auth.application.port.out;
 
 import io.wisoft.avocadobackendhexagonal.domain.member.domain.Member;
 

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/auth/application/port/out/SignUpPort.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/auth/application/port/out/SignUpPort.java
@@ -1,8 +1,0 @@
-package io.wisoft.avocadobackendhexagonal.domain.auth.application.port.out;
-
-import io.wisoft.avocadobackendhexagonal.domain.member.domain.Member;
-
-public interface SignUpPort {
-
-    Long signup(Member member);
-}

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/auth/application/service/SignUpService.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/auth/application/service/SignUpService.java
@@ -1,8 +1,8 @@
-package io.wisoft.avocadobackendhexagonal.domain.member.application.service;
+package io.wisoft.avocadobackendhexagonal.domain.auth.application.service;
 
-import io.wisoft.avocadobackendhexagonal.domain.member.application.port.in.SignupUseCase;
-import io.wisoft.avocadobackendhexagonal.domain.member.application.port.in.command.SignupCommand;
-import io.wisoft.avocadobackendhexagonal.domain.member.application.port.out.SignUpPort;
+import io.wisoft.avocadobackendhexagonal.domain.auth.application.port.in.SignupUseCase;
+import io.wisoft.avocadobackendhexagonal.domain.auth.application.port.in.command.SignupCommand;
+import io.wisoft.avocadobackendhexagonal.domain.auth.application.port.out.SignUpPort;
 import io.wisoft.avocadobackendhexagonal.domain.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/auth/application/service/SignUpService.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/auth/application/service/SignUpService.java
@@ -2,7 +2,7 @@ package io.wisoft.avocadobackendhexagonal.domain.auth.application.service;
 
 import io.wisoft.avocadobackendhexagonal.domain.auth.application.port.in.SignupUseCase;
 import io.wisoft.avocadobackendhexagonal.domain.auth.application.port.in.command.SignupCommand;
-import io.wisoft.avocadobackendhexagonal.domain.auth.application.port.out.SignUpPort;
+import io.wisoft.avocadobackendhexagonal.domain.member.application.port.out.SaveMemberPort;
 import io.wisoft.avocadobackendhexagonal.domain.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,13 +11,13 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class SignUpService implements SignupUseCase {
 
-    private final SignUpPort signUpPort;
+    private final SaveMemberPort saveMemberPort;
 
     @Override
     public Long signup(final SignupCommand request) {
 
         final Member member = Member.withoutId(request.email(), request.password());
 
-        return signUpPort.signup(member);
+        return saveMemberPort.save(member);
     }
 }

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/adapter/in/web/DeleteMemberController.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/adapter/in/web/DeleteMemberController.java
@@ -1,0 +1,21 @@
+package io.wisoft.avocadobackendhexagonal.domain.member.adapter.in.web;
+
+import io.wisoft.avocadobackendhexagonal.domain.member.application.port.in.DeleteMemberUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class DeleteMemberController {
+
+    private final DeleteMemberUseCase deleteMemberUseCase;
+
+    @DeleteMapping("/api/members/{id}")
+    public ResponseEntity<Void> deleteMember(@PathVariable("id") final Long id) {
+        deleteMemberUseCase.delete(id);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/adapter/in/web/LoadMemberController.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/adapter/in/web/LoadMemberController.java
@@ -1,0 +1,37 @@
+package io.wisoft.avocadobackendhexagonal.domain.member.adapter.in.web;
+
+import io.wisoft.avocadobackendhexagonal.domain.member.adapter.in.web.dto.MemberDto;
+import io.wisoft.avocadobackendhexagonal.domain.member.application.port.in.LoadMemberUseCase;
+import io.wisoft.avocadobackendhexagonal.domain.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class LoadMemberController {
+
+    private final LoadMemberUseCase loadMemberUseCase;
+
+    @GetMapping("/api/members/{id}/details")
+    public ResponseEntity<MemberDto> member(@PathVariable("id") final Long id) {
+        final Member member = loadMemberUseCase.loadMember(id);
+        return ResponseEntity.ok(getMemberDto(member));
+    }
+
+    @GetMapping("/api/members")
+    public List<MemberDto> members() {
+        final List<Member> members = loadMemberUseCase.loadMemberList();
+        return members.stream()
+                .map(member -> getMemberDto(member))
+                .toList();
+    }
+
+    private static MemberDto getMemberDto(final Member member) {
+        return new MemberDto(member.getId(), member.getEmail());
+    }
+}

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/adapter/in/web/UpdateMemberController.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/adapter/in/web/UpdateMemberController.java
@@ -1,0 +1,24 @@
+package io.wisoft.avocadobackendhexagonal.domain.member.adapter.in.web;
+
+import io.wisoft.avocadobackendhexagonal.domain.member.application.port.in.UpdateMemberUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UpdateMemberController {
+
+    private final UpdateMemberUseCase updateMemberUseCase;
+
+    @PatchMapping("/api/members/{id}")
+    public ResponseEntity<Long> updateMember(
+            @PathVariable("id") final Long id,
+            @RequestParam(value = "email", required = false) final String email) {
+
+        return ResponseEntity.ok(updateMemberUseCase.updateMember(id, email));
+    }
+}

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/adapter/in/web/dto/MemberDto.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/adapter/in/web/dto/MemberDto.java
@@ -1,0 +1,11 @@
+package io.wisoft.avocadobackendhexagonal.domain.member.adapter.in.web.dto;
+
+public record MemberDto(
+        Long id,
+        String email
+) {
+    public MemberDto(Long id, String email) {
+        this.id = id;
+        this.email = email;
+    }
+}

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/adapter/out/persistence/adapter/MemberPersistenceAdapter.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/adapter/out/persistence/adapter/MemberPersistenceAdapter.java
@@ -4,7 +4,7 @@ import io.wisoft.avocadobackendhexagonal.domain.member.adapter.out.persistence.M
 import io.wisoft.avocadobackendhexagonal.domain.member.adapter.out.persistence.MemberMapper;
 import io.wisoft.avocadobackendhexagonal.domain.member.adapter.out.persistence.MemberRepository;
 import io.wisoft.avocadobackendhexagonal.domain.member.application.port.out.LoadMemberPort;
-import io.wisoft.avocadobackendhexagonal.domain.member.application.port.out.SignUpPort;
+import io.wisoft.avocadobackendhexagonal.domain.auth.application.port.out.SignUpPort;
 import io.wisoft.avocadobackendhexagonal.domain.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/adapter/out/persistence/adapter/MemberPersistenceAdapter.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/adapter/out/persistence/adapter/MemberPersistenceAdapter.java
@@ -3,29 +3,43 @@ package io.wisoft.avocadobackendhexagonal.domain.member.adapter.out.persistence.
 import io.wisoft.avocadobackendhexagonal.domain.member.adapter.out.persistence.MemberEntity;
 import io.wisoft.avocadobackendhexagonal.domain.member.adapter.out.persistence.MemberMapper;
 import io.wisoft.avocadobackendhexagonal.domain.member.adapter.out.persistence.MemberRepository;
+import io.wisoft.avocadobackendhexagonal.domain.member.application.port.out.DeleteMemberPort;
+import io.wisoft.avocadobackendhexagonal.domain.member.application.port.out.SaveMemberPort;
 import io.wisoft.avocadobackendhexagonal.domain.member.application.port.out.LoadMemberPort;
-import io.wisoft.avocadobackendhexagonal.domain.auth.application.port.out.SignUpPort;
 import io.wisoft.avocadobackendhexagonal.domain.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
-public class MemberPersistenceAdapter implements SignUpPort, LoadMemberPort {
+public class MemberPersistenceAdapter implements LoadMemberPort, SaveMemberPort, DeleteMemberPort {
 
     private final MemberRepository memberRepository;
 
-
     @Override
-    public Long signup(final Member member) {
-        return memberRepository.save(MemberMapper.memberToMemberEntity(member)).getId();
-    }
-
-    @Override
-    public Member findById(Long memberId) {
+    public Member findById(final Long memberId) {
         final MemberEntity memberEntity = memberRepository.findById(memberId)
                 .orElseThrow(IllegalArgumentException::new);
 
         return MemberMapper.memberEntityToMember(memberEntity);
+    }
+
+    @Override
+    public List<Member> findAll() {
+        return memberRepository.findAll().stream()
+                .map(memberEntity ->  MemberMapper.memberEntityToMember(memberEntity))
+                .toList();
+    }
+
+    @Override
+    public Long save(final Member member) {
+        return memberRepository.save(MemberMapper.memberToMemberEntity(member)).getId();
+    }
+
+    @Override
+    public void delete(final Member member) {
+        memberRepository.delete(MemberMapper.memberToMemberEntity(member));
     }
 }

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/application/port/in/DeleteMemberUseCase.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/application/port/in/DeleteMemberUseCase.java
@@ -1,0 +1,8 @@
+package io.wisoft.avocadobackendhexagonal.domain.member.application.port.in;
+
+import io.wisoft.avocadobackendhexagonal.domain.member.domain.Member;
+
+public interface DeleteMemberUseCase {
+
+    void delete(final Long memberId);
+}

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/application/port/in/LoadMemberUseCase.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/application/port/in/LoadMemberUseCase.java
@@ -1,0 +1,11 @@
+package io.wisoft.avocadobackendhexagonal.domain.member.application.port.in;
+
+import io.wisoft.avocadobackendhexagonal.domain.member.domain.Member;
+
+import java.util.List;
+
+public interface LoadMemberUseCase {
+
+    Member loadMember(final Long memberId);
+    List<Member> loadMemberList();
+}

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/application/port/in/SignupUseCase.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/application/port/in/SignupUseCase.java
@@ -1,8 +1,0 @@
-package io.wisoft.avocadobackendhexagonal.domain.member.application.port.in;
-
-import io.wisoft.avocadobackendhexagonal.domain.member.application.port.in.command.SignupCommand;
-
-public interface SignupUseCase {
-
-    Long signup(final SignupCommand request);
-}

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/application/port/in/UpdateMemberUseCase.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/application/port/in/UpdateMemberUseCase.java
@@ -1,0 +1,6 @@
+package io.wisoft.avocadobackendhexagonal.domain.member.application.port.in;
+
+public interface UpdateMemberUseCase {
+
+    Long updateMember(final Long memberId, final String email);
+}

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/application/port/out/DeleteMemberPort.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/application/port/out/DeleteMemberPort.java
@@ -2,11 +2,6 @@ package io.wisoft.avocadobackendhexagonal.domain.member.application.port.out;
 
 import io.wisoft.avocadobackendhexagonal.domain.member.domain.Member;
 
-import java.util.List;
-
-public interface LoadMemberPort {
-
-    Member findById(final Long memberId);
-
-    List<Member> findAll();
+public interface DeleteMemberPort {
+    void delete(Member member);
 }

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/application/port/out/SaveMemberPort.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/application/port/out/SaveMemberPort.java
@@ -2,11 +2,7 @@ package io.wisoft.avocadobackendhexagonal.domain.member.application.port.out;
 
 import io.wisoft.avocadobackendhexagonal.domain.member.domain.Member;
 
-import java.util.List;
+public interface SaveMemberPort {
 
-public interface LoadMemberPort {
-
-    Member findById(final Long memberId);
-
-    List<Member> findAll();
+    Long save(final Member member);
 }

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/application/service/DeleteMemberService.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/application/service/DeleteMemberService.java
@@ -1,0 +1,22 @@
+package io.wisoft.avocadobackendhexagonal.domain.member.application.service;
+
+import io.wisoft.avocadobackendhexagonal.domain.member.application.port.in.DeleteMemberUseCase;
+import io.wisoft.avocadobackendhexagonal.domain.member.application.port.out.DeleteMemberPort;
+import io.wisoft.avocadobackendhexagonal.domain.member.application.port.out.LoadMemberPort;
+import io.wisoft.avocadobackendhexagonal.domain.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteMemberService implements DeleteMemberUseCase {
+
+    private final DeleteMemberPort deleteMemberPort;
+    private final LoadMemberPort loadMemberPort;
+
+    @Override
+    public void delete(final Long memberId) {
+        final Member member = loadMemberPort.findById(memberId);
+        deleteMemberPort.delete(member);
+    }
+}

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/application/service/LoadMemberService.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/application/service/LoadMemberService.java
@@ -1,0 +1,26 @@
+package io.wisoft.avocadobackendhexagonal.domain.member.application.service;
+
+import io.wisoft.avocadobackendhexagonal.domain.member.application.port.in.LoadMemberUseCase;
+import io.wisoft.avocadobackendhexagonal.domain.member.application.port.out.LoadMemberPort;
+import io.wisoft.avocadobackendhexagonal.domain.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class LoadMemberService implements LoadMemberUseCase {
+
+    private final LoadMemberPort loadMemberPort;
+
+    @Override
+    public Member loadMember(final Long memberId) {
+        return loadMemberPort.findById(memberId);
+    }
+
+    @Override
+    public List<Member> loadMemberList() {
+        return loadMemberPort.findAll();
+    }
+}

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/application/service/UpdateMemberService.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/application/service/UpdateMemberService.java
@@ -1,0 +1,25 @@
+package io.wisoft.avocadobackendhexagonal.domain.member.application.service;
+
+import io.wisoft.avocadobackendhexagonal.domain.member.application.port.out.SaveMemberPort;
+import io.wisoft.avocadobackendhexagonal.domain.member.application.port.in.UpdateMemberUseCase;
+import io.wisoft.avocadobackendhexagonal.domain.member.application.port.out.LoadMemberPort;
+import io.wisoft.avocadobackendhexagonal.domain.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateMemberService implements UpdateMemberUseCase {
+
+    private final LoadMemberPort loadMemberPort;
+    private final SaveMemberPort saveMemberPort;
+
+    @Override
+    public Long updateMember(final Long memberId, final String email) {
+
+        final Member member = loadMemberPort.findById(memberId);
+        member.update(email);
+
+        return saveMemberPort.save(member);
+    }
+}

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/domain/Member.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/member/domain/Member.java
@@ -25,4 +25,8 @@ public class Member {
 
         return member;
     }
+
+    public void update(final String email) {
+        this.email = email;
+    }
 }


### PR DESCRIPTION
## What is this PR? 📍
회원 마이페이지 기능을 제외한 회원 도메인 기능을 개발하였습니다.
- 회원 단건 조회
- 회원 목록 조회
- 회원 정보 수정
- 회원 탈퇴

<br/>

## Changes 🔍
기존에 작성했던 회원가입 로직은 Auth 패키지로 이전하였습니다.

<br/>
 
## Todo 🗓️
마이페이지 기능 구현하기

<br/>