### PR TITLE
feat : 로그아웃 유스케이스 작성(#14)

### DIFF
--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/auth/adapter/in/web/LogoutController.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/auth/adapter/in/web/LogoutController.java
@@ -1,0 +1,29 @@
+package io.wisoft.avocadobackendhexagonal.domain.auth.adapter.in.web;
+
+import io.wisoft.avocadobackendhexagonal.domain.auth.application.port.in.LogoutUseCase;
+import io.wisoft.avocadobackendhexagonal.global.jwt.AuthorizationExtractor;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class LogoutController {
+
+    private final AuthorizationExtractor authExtractor;
+    private final LogoutUseCase logoutUseCase;
+
+
+    @PostMapping("/logout")
+    public ResponseEntity<String> logoutMember(final HttpServletRequest request) {
+
+        final String accessToken = authExtractor.extract(request, "Bearer");
+
+        logoutUseCase.logout(accessToken);
+        return ResponseEntity.ok("logout success");
+    }
+}

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/auth/application/port/in/LogoutUseCase.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/auth/application/port/in/LogoutUseCase.java
@@ -1,0 +1,6 @@
+package io.wisoft.avocadobackendhexagonal.domain.auth.application.port.in;
+
+public interface LogoutUseCase {
+
+    void logout(final String accessToken);
+}

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/auth/application/service/LogoutService.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/auth/application/service/LogoutService.java
@@ -1,0 +1,26 @@
+package io.wisoft.avocadobackendhexagonal.domain.auth.application.service;
+
+import io.wisoft.avocadobackendhexagonal.domain.auth.application.port.in.LogoutUseCase;
+import io.wisoft.avocadobackendhexagonal.global.jwt.JwtTokenProvider;
+import io.wisoft.avocadobackendhexagonal.global.jwt.RedisJwtBlackList;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LogoutService implements LogoutUseCase {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RedisJwtBlackList redisJwtBlackList;
+
+    @Override
+    @Transactional
+    public void logout(final String accessToken) {
+
+        final String email = jwtTokenProvider.getSubject(accessToken);
+        redisJwtBlackList.addToBlackList(email);
+    }
+}

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/global/exception/ErrorCode.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/global/exception/ErrorCode.java
@@ -9,7 +9,9 @@ import lombok.NoArgsConstructor;
 public enum ErrorCode {
 
     //COMMON
+    ASSERT_INVALID_INPUT(400, "Common-Builder-400", "Builder가 요구하는 필수 파라미터가 요구되지 않았습니다."),
     NOT_FOUND(404, "Common-NotFound-404", "해당 엔티티를 찾을 수 없습니다."),
+    TIME_OUT(500, "Common-TimeOut-500", "Timeout 발생"),
 
     //DUPLICATE,
     DUPLICATE_EMAIL(400, "Duplicate-Mail-400", "Email is duplicated"),
@@ -26,7 +28,10 @@ public enum ErrorCode {
     INVALID_PASSWORD(400, "Illegal-400", "Invalid password1"),
     ILLEGAL_INPUT(400, "Illegal-400", "Invalid input"),
     INVALID_TOKEN(400, "Token-400", "Invalid token"),
-    EXPIRED_TOKEN(400, "Token-400", "Expired token");
+    EXPIRED_TOKEN(400, "Token-400", "Expired token"),
+    ALREADY_LOGOUT_TOKEN(403, "Token-403", "Already logout token"),
+    JWT_EXCEPTION(400, "Token-400", "JWT is invalid"),
+    NOT_EXIST_TOKEN(401, "Illegal-Not-Exist-Token-401", "Token is not exist");
 
     private int httpStatusCode;
     private String errorCode;

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/global/exception/token/AlreadyLogoutException.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/global/exception/token/AlreadyLogoutException.java
@@ -1,0 +1,15 @@
+package io.wisoft.avocadobackendhexagonal.global.exception.token;
+
+import io.wisoft.avocadobackendhexagonal.global.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class AlreadyLogoutException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public AlreadyLogoutException(final String message, final ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/global/interceptor/BearerAuthInterceptor.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/global/interceptor/BearerAuthInterceptor.java
@@ -1,0 +1,52 @@
+package io.wisoft.avocadobackendhexagonal.global.interceptor;
+
+import io.wisoft.avocadobackendhexagonal.global.exception.ErrorCode;
+import io.wisoft.avocadobackendhexagonal.global.exception.token.NotExistTokenException;
+import io.wisoft.avocadobackendhexagonal.global.jwt.AuthorizationExtractor;
+import io.wisoft.avocadobackendhexagonal.global.jwt.JwtTokenProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class BearerAuthInterceptor implements HandlerInterceptor {
+    private final AuthorizationExtractor authExtractor;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final Logger logger = LoggerFactory.getLogger(BearerAuthInterceptor.class);
+
+    public BearerAuthInterceptor(
+            final AuthorizationExtractor authExtractor,
+            final JwtTokenProvider jwtTokenProvider) {
+        this.authExtractor = authExtractor;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public boolean preHandle(
+            final HttpServletRequest request,
+            final HttpServletResponse response,
+            final Object handler) {
+
+        logger.info("interceptor.preHandle 호출");
+
+        final String accessToken = authExtractor.extract(request, "Bearer");
+
+        if (!StringUtils.hasText(accessToken)) {
+            logger.error("토큰이 적재되지 않음");
+            throw new NotExistTokenException("토큰이 적재되지 않음", ErrorCode.NOT_EXIST_TOKEN);
+        }
+
+        //토큰을 디코딩
+        final String email = jwtTokenProvider.getSubject(accessToken);
+
+        jwtTokenProvider.validateToken(email);
+
+        //디코딩한 값으로 세팅
+        request.setAttribute("email", email);
+        return true;
+    }
+}


### PR DESCRIPTION
## What is this PR? 📍
로그아웃 유스케이스를 개발합니다.

로그아웃 요청이 들어오면, 헤더로부터 해당 AccessToken을 추출하고, AccessToken으로부터 subject(email)를 추출합니다.
이후, Redis에 key를 subject로, value를 `LOGOUT_STATUS`라는 문자열로 지정합니다.

로그아웃된 토큰으로 요청이 들어올 경우, 유효성 검증 과정에서 Redis에서 key가 subject인 값이 있는지를 확인하고
값이 있다면 value를 얻어 `LOGOUT_STATUS` 인지를 비교해 로그아웃 여부를 판단하도록 하였습니다.

<br/>

## Changes 🔍
초안 로그아웃 유스케이스
- AccessToken 자체를 key로 저장하도록 함
- 이 경우, Redis에 해당 AccessToken을 key로 하는 값이 있는지를 판별해 값이 있으면 로그아웃된 토큰임을 인지

<br/>


위 방식의 문제점
- 로그인의 경우에는 subject(=email)을 key로 하던 방식인데, 로그아웃에는 token을 key로 하는 방식이므로,
- 개발자의 실수를 유발할 것 같아 subject를 key로 저장하던 방식으로 수정하였습니다.

<br/>
 
## Todo 🗓️

<br/>