### PR TITLE
Test : 의료진 기능 관련 테스트 코드 작성

### DIFF
--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/hospital/adapter/out/persistence/HospitalEntity.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/hospital/adapter/out/persistence/HospitalEntity.java
@@ -31,7 +31,7 @@ public class HospitalEntity extends BaseTimeEntity {
     @Column(name = "hosp_operatingtime", columnDefinition="TEXT")
     private String operatingTime;
 
-    @OneToMany(mappedBy = "hospital")
+    @OneToMany(mappedBy = "hospital", cascade = CascadeType.REMOVE)
     private final List<StaffEntity> staffList = new ArrayList<>();
 
     public static HospitalEntity createHospital(

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/staff/adapter/in/web/dto/UpdateStaffPasswordRequest.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/staff/adapter/in/web/dto/UpdateStaffPasswordRequest.java
@@ -1,9 +1,15 @@
 package io.wisoft.avocadobackendhexagonal.domain.staff.adapter.in.web.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 public record UpdateStaffPasswordRequest(
+        @Pattern(regexp="(?=.*[0-9])(?=.*[a-zA-Z])(?=\\S+$).{4,20}",
+                message = "비밀번호는 영문과 숫자가 포함된 4자 ~ 20자의 비밀번호여야 합니다.")
         @NotBlank String oldPassword,
+
+        @Pattern(regexp="(?=.*[0-9])(?=.*[a-zA-Z])(?=\\S+$).{4,20}",
+                message = "비밀번호는 영문과 숫자가 포함된 4자 ~ 20자의 비밀번호여야 합니다.")
         @NotBlank String newPassword
 ) {
 }

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/staff/application/service/UpdateStaffService.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/staff/application/service/UpdateStaffService.java
@@ -54,7 +54,7 @@ public class UpdateStaffService implements UpdateStaffUseCase {
     }
 
     private void validatePassword(final String password, final String oldPassword) {
-        if (!encryptHelper.isMatch(password, oldPassword)) {
+        if (!encryptHelper.isMatch(oldPassword, password)) {
             throw new CustomIllegalException("password is invalid", ErrorCode.INVALID_PASSWORD);
         }
     }

--- a/src/main/java/io/wisoft/avocadobackendhexagonal/domain/staff/application/service/UpdateStaffService.java
+++ b/src/main/java/io/wisoft/avocadobackendhexagonal/domain/staff/application/service/UpdateStaffService.java
@@ -6,6 +6,9 @@ import io.wisoft.avocadobackendhexagonal.domain.staff.application.port.in.Update
 import io.wisoft.avocadobackendhexagonal.domain.staff.application.port.in.command.UpdateStaffPasswordCommand;
 import io.wisoft.avocadobackendhexagonal.domain.staff.application.port.out.LoadStaffPort;
 import io.wisoft.avocadobackendhexagonal.domain.staff.domain.Staff;
+import io.wisoft.avocadobackendhexagonal.global.config.bcrypt.EncryptHelper;
+import io.wisoft.avocadobackendhexagonal.global.exception.ErrorCode;
+import io.wisoft.avocadobackendhexagonal.global.exception.Illegal.CustomIllegalException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -17,6 +20,7 @@ import org.springframework.util.StringUtils;
 @RequiredArgsConstructor
 public class UpdateStaffService implements UpdateStaffUseCase {
 
+    private final EncryptHelper encryptHelper;
     private final LoadStaffPort loadStaffPort;
     private final SaveStaffPort saveStaffPort;
     private final LoadHospitalPort loadHospitalPort;
@@ -45,14 +49,13 @@ public class UpdateStaffService implements UpdateStaffUseCase {
         final Staff staff = loadStaffPort.findById(staffId);
         validatePassword(staff.getPassword(), command.oldPassword());
 
-        staff.updatePassword(command.newPassword());
+        staff.updatePassword(encryptHelper.encrypt(command.newPassword()));
         return saveStaffPort.save(staff);
     }
 
     private void validatePassword(final String password, final String oldPassword) {
-        if (!password.equals(oldPassword)) {
-            log.error("비밀번호가 일치하지 않아 비밀번호를 수정할 수 없습니다.");
-            throw new IllegalArgumentException("비밀번호가 일치하지 않아 비밀번호를 수정할 수 없습니다.");
+        if (!encryptHelper.isMatch(password, oldPassword)) {
+            throw new CustomIllegalException("password is invalid", ErrorCode.INVALID_PASSWORD);
         }
     }
 }

--- a/src/test/java/io/wisoft/avocadobackendhexagonal/domain/staff/adapter/in/web/DeleteStaffControllerTest.java
+++ b/src/test/java/io/wisoft/avocadobackendhexagonal/domain/staff/adapter/in/web/DeleteStaffControllerTest.java
@@ -1,0 +1,91 @@
+package io.wisoft.avocadobackendhexagonal.domain.staff.adapter.in.web;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.wisoft.avocadobackendhexagonal.domain.auth.adapter.in.web.dto.SignupStaffRequest;
+import io.wisoft.avocadobackendhexagonal.domain.hospital.adapter.in.web.dto.RegisterHospitalRequest;
+import io.wisoft.avocadobackendhexagonal.domain.staff.adapter.out.persistence.StaffRepository;
+import io.wisoft.avocadobackendhexagonal.settings.common.ControllerTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class DeleteStaffControllerTest extends ControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private StaffRepository staffRepository;
+
+    @BeforeEach
+    void clean() throws Exception {
+
+        staffRepository.deleteAll();
+
+        //병원 등록
+        mockMvc.perform(post("/api/hospitals")
+                        .contentType(APPLICATION_JSON)
+                        .content(getHospitalRequestString()))
+                .andExpect(status().isOk())
+                .andDo(print());
+
+        //의료진 가입
+        mockMvc.perform(post("/api/auth/signup/staff")
+                        .contentType(APPLICATION_JSON)
+                        .content(getSignupStaffRequest()))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+    
+    
+    @Test
+    public void delete_success() throws Exception {
+        //given -- 조건
+        final Long deleteId = 1L;
+
+        //expected
+        mockMvc.perform(delete("/api/staff/{id}", deleteId))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+
+    private RegisterHospitalRequest getHospitalRequest() {
+        return new RegisterHospitalRequest(
+                "name",
+                "number",
+                "address",
+                "operatingTime"
+        );
+    }
+
+    private String getHospitalRequestString() throws JsonProcessingException {
+        final var hospitalRequest = getHospitalRequest();
+
+        final String hospitalRequestString = objectMapper.writeValueAsString(hospitalRequest);
+        return hospitalRequestString;
+    }
+
+    private String getSignupStaffRequest() throws JsonProcessingException {
+        final var request = new SignupStaffRequest(
+                "name",
+                "email@email.com",
+                "password123",
+                "password123",
+                "license",
+                "DENTAL",
+                1L
+        );
+
+        return objectMapper.writeValueAsString(request);
+    }
+}

--- a/src/test/java/io/wisoft/avocadobackendhexagonal/domain/staff/adapter/in/web/LoadStaffControllerTest.java
+++ b/src/test/java/io/wisoft/avocadobackendhexagonal/domain/staff/adapter/in/web/LoadStaffControllerTest.java
@@ -1,0 +1,97 @@
+package io.wisoft.avocadobackendhexagonal.domain.staff.adapter.in.web;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.wisoft.avocadobackendhexagonal.domain.auth.adapter.in.web.dto.SignupStaffRequest;
+import io.wisoft.avocadobackendhexagonal.domain.hospital.adapter.in.web.dto.RegisterHospitalRequest;
+import io.wisoft.avocadobackendhexagonal.domain.hospital.adapter.out.persistence.HospitalRepository;
+import io.wisoft.avocadobackendhexagonal.domain.staff.adapter.out.persistence.StaffRepository;
+import io.wisoft.avocadobackendhexagonal.settings.common.ControllerTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class LoadStaffControllerTest extends ControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private StaffRepository staffRepository;
+    @Autowired
+    private HospitalRepository hospitalRepository;
+
+    @BeforeEach
+    void clean() throws Exception {
+        hospitalRepository.deleteAll();
+        staffRepository.deleteAll();
+
+        //병원 등록
+        mockMvc.perform(post("/api/hospitals")
+                        .contentType(APPLICATION_JSON)
+                        .content(getHospitalRequestString()))
+                .andExpect(status().isOk())
+                .andDo(print());
+
+        //의료진 가입
+        mockMvc.perform(post("/api/auth/signup/staff")
+                        .contentType(APPLICATION_JSON)
+                        .content(getSignupStaffRequest()))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+
+    @Test
+    @DisplayName("의료진 단건 조회 성공 테스트")
+    public void loadStaff_success() throws Exception {
+        //expected
+        mockMvc.perform(
+                        get("/api/staff/{id}/details", 1))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("name"))
+                .andExpect(jsonPath("$.email").value("email@email.com"))
+                .andDo(print());
+    }
+
+
+    private RegisterHospitalRequest getHospitalRequest() {
+        return new RegisterHospitalRequest(
+                "name",
+                "number",
+                "address",
+                "operatingTime"
+        );
+    }
+
+    private String getHospitalRequestString() throws JsonProcessingException {
+        final var hospitalRequest = getHospitalRequest();
+
+        final String hospitalRequestString = objectMapper.writeValueAsString(hospitalRequest);
+        return hospitalRequestString;
+    }
+
+    private String getSignupStaffRequest() throws JsonProcessingException {
+        final var request = new SignupStaffRequest(
+                "name",
+                "email@email.com",
+                "password123",
+                "password123",
+                "license",
+                "DENTAL",
+                1L
+        );
+
+        return objectMapper.writeValueAsString(request);
+    }
+}

--- a/src/test/java/io/wisoft/avocadobackendhexagonal/domain/staff/adapter/in/web/UpdateStaffControllerTest.java
+++ b/src/test/java/io/wisoft/avocadobackendhexagonal/domain/staff/adapter/in/web/UpdateStaffControllerTest.java
@@ -1,0 +1,100 @@
+package io.wisoft.avocadobackendhexagonal.domain.staff.adapter.in.web;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.wisoft.avocadobackendhexagonal.domain.auth.adapter.in.web.dto.SignupStaffRequest;
+import io.wisoft.avocadobackendhexagonal.domain.hospital.adapter.in.web.dto.RegisterHospitalRequest;
+import io.wisoft.avocadobackendhexagonal.domain.staff.adapter.in.web.dto.UpdateStaffPasswordRequest;
+import io.wisoft.avocadobackendhexagonal.domain.staff.adapter.out.persistence.StaffRepository;
+import io.wisoft.avocadobackendhexagonal.settings.common.ControllerTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+class UpdateStaffControllerTest extends ControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private StaffRepository staffRepository;
+
+    @BeforeEach
+    void clean() throws Exception {
+        staffRepository.deleteAll();
+
+        //병원 등록
+        mockMvc.perform(post("/api/hospitals")
+                        .contentType(APPLICATION_JSON)
+                        .content(getHospitalRequestString()))
+                .andExpect(status().isOk())
+                .andDo(print());
+
+        //의료진 가입
+        mockMvc.perform(post("/api/auth/signup/staff")
+                        .contentType(APPLICATION_JSON)
+                        .content(getSignupStaffRequest()))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    public void updateStaffPassword() throws Exception {
+        //given
+        final var request = getUpdatePasswordRequest();
+
+        //expected
+        mockMvc.perform(
+                        patch("/api/staff/{id}/password", 1L)
+                                .contentType(APPLICATION_JSON)
+                                .content(request))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    private String getUpdatePasswordRequest() throws JsonProcessingException {
+        final var request = new UpdateStaffPasswordRequest(
+                "password123", "updatePassword123"
+        );
+
+        return objectMapper.writeValueAsString(request);
+    }
+
+    private RegisterHospitalRequest getHospitalRequest() {
+        return new RegisterHospitalRequest(
+                "name",
+                "number",
+                "address",
+                "operatingTime"
+        );
+    }
+
+    private String getHospitalRequestString() throws JsonProcessingException {
+        final var hospitalRequest = getHospitalRequest();
+
+        return objectMapper.writeValueAsString(hospitalRequest);
+    }
+
+    private String getSignupStaffRequest() throws JsonProcessingException {
+        final var request = new SignupStaffRequest(
+                "name",
+                "email@email.com",
+                "password123",
+                "password123",
+                "license",
+                "DENTAL",
+                1L
+        );
+
+        return objectMapper.writeValueAsString(request);
+    }
+}

--- a/src/test/java/io/wisoft/avocadobackendhexagonal/domain/staff/adapter/out/persistence/adapter/StaffPersistenceAdapterTest.java
+++ b/src/test/java/io/wisoft/avocadobackendhexagonal/domain/staff/adapter/out/persistence/adapter/StaffPersistenceAdapterTest.java
@@ -1,0 +1,84 @@
+package io.wisoft.avocadobackendhexagonal.domain.staff.adapter.out.persistence.adapter;
+
+import io.wisoft.avocadobackendhexagonal.domain.hospital.adapter.out.persistence.adapter.HospitalPersistenceAdapter;
+import io.wisoft.avocadobackendhexagonal.domain.hospital.domain.Hospital;
+import io.wisoft.avocadobackendhexagonal.domain.staff.adapter.out.persistence.StaffEntity;
+import io.wisoft.avocadobackendhexagonal.domain.staff.domain.Staff;
+import io.wisoft.avocadobackendhexagonal.global.enumeration.HospitalDept;
+import io.wisoft.avocadobackendhexagonal.settings.common.PersistenceAdapterTest;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+@Import({StaffPersistenceAdapter.class, HospitalPersistenceAdapter.class})
+class StaffPersistenceAdapterTest extends PersistenceAdapterTest {
+
+    @Autowired
+    private HospitalPersistenceAdapter hospitalPersistenceAdapter;
+
+    @Autowired
+    private StaffPersistenceAdapter staffPersistenceAdapter;
+
+    @Test
+    public void save_success() throws Exception {
+        //given -- 조건
+
+        final Hospital hospital = getHospital();
+
+        hospitalPersistenceAdapter.save(hospital);
+
+        final Staff staff = getStaff(hospital);
+
+        //when -- 동작
+        final Long saveId = staffPersistenceAdapter.save(staff);
+
+        //then -- 검증
+        final Staff findStaff = staffPersistenceAdapter.findById(saveId);
+
+        Assertions.assertThat(findStaff.getName()).isEqualTo("name");
+    }
+
+
+    @Test
+    public void delete_success() throws Exception {
+        final Hospital hospital = getHospital();
+
+        hospitalPersistenceAdapter.save(hospital);
+
+        final Staff staff = getStaff(hospital);
+        final Long saveId = staffPersistenceAdapter.save(staff);
+
+        //when -- 동작
+        final StaffEntity findStaffEntity = staffPersistenceAdapter.findStaffEntityById(saveId);
+        staffPersistenceAdapter.delete(findStaffEntity);
+
+        //then -- 검증
+        Assertions.assertThat(staffPersistenceAdapter.existsByEmail(staff.getEmail())).isFalse();
+    }
+
+
+    private Staff getStaff(final Hospital hospital) {
+        return Staff.createStaff(
+                1L,
+                "name",
+                "email",
+                "password",
+                "license",
+                "photo",
+                HospitalDept.DENTAL,
+                hospital
+        );
+    }
+
+    private Hospital getHospital() {
+        return Hospital.registerHospital(
+                null,
+                "name",
+                "number",
+                "address",
+                "operatingTime"
+        );
+    }
+
+}

--- a/src/test/java/io/wisoft/avocadobackendhexagonal/domain/staff/application/service/DeleteStaffServiceTest.java
+++ b/src/test/java/io/wisoft/avocadobackendhexagonal/domain/staff/application/service/DeleteStaffServiceTest.java
@@ -1,0 +1,64 @@
+package io.wisoft.avocadobackendhexagonal.domain.staff.application.service;
+
+import io.wisoft.avocadobackendhexagonal.domain.auth.application.port.in.command.SignupStaffCommand;
+import io.wisoft.avocadobackendhexagonal.domain.auth.application.service.SignUpService;
+import io.wisoft.avocadobackendhexagonal.domain.hospital.application.port.out.SaveHospitalPort;
+import io.wisoft.avocadobackendhexagonal.domain.hospital.domain.Hospital;
+import io.wisoft.avocadobackendhexagonal.domain.staff.application.port.out.LoadStaffPort;
+import io.wisoft.avocadobackendhexagonal.global.exception.notfound.CustomNotFoundException;
+import io.wisoft.avocadobackendhexagonal.settings.common.ServiceTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class DeleteStaffServiceTest extends ServiceTest {
+
+    @Autowired private SignUpService signUpService;
+    @Autowired private LoadStaffPort loadStaffPort;
+    @Autowired private SaveHospitalPort saveHospitalPort;
+    @Autowired private DeleteStaffService deleteStaffService;
+
+    @Test
+    @DisplayName("삭제된 회원을 조회할 시 404 예외가 발생해야 한다.")
+    public void delete_success() throws Exception {
+
+        //given -- 조건
+        //병원 생성 및 저장
+        final Hospital hospital = getHospital();
+        final Long savedHospitalId = saveHospitalPort.save(hospital);
+
+        //의료진 가입 및 저장
+        final var signupStaffCommand = getSignupStaffCommand(savedHospitalId);
+        final Long savedStaffId = signUpService.signupStaff(signupStaffCommand);
+
+        //when -- 동작
+        deleteStaffService.delete(savedStaffId);
+
+        //then -- 검증
+        Assertions.assertThrows(CustomNotFoundException.class, () -> {
+            loadStaffPort.findById(savedStaffId);
+        });
+    }
+
+    private SignupStaffCommand getSignupStaffCommand(final Long savedHospitalId) {
+        return new SignupStaffCommand(
+                "name",
+                "email",
+                "password",
+                "license",
+                "DENTAL",
+                savedHospitalId
+        );
+    }
+
+    private Hospital getHospital() {
+        return Hospital.registerHospital(
+                null,
+                "name",
+                "number",
+                "address",
+                "oper"
+        );
+    }
+}

--- a/src/test/java/io/wisoft/avocadobackendhexagonal/domain/staff/application/service/LoadStaffServiceTest.java
+++ b/src/test/java/io/wisoft/avocadobackendhexagonal/domain/staff/application/service/LoadStaffServiceTest.java
@@ -1,0 +1,121 @@
+package io.wisoft.avocadobackendhexagonal.domain.staff.application.service;
+
+import io.wisoft.avocadobackendhexagonal.domain.auth.application.port.in.command.SignupStaffCommand;
+import io.wisoft.avocadobackendhexagonal.domain.auth.application.service.SignUpService;
+import io.wisoft.avocadobackendhexagonal.domain.hospital.application.port.out.SaveHospitalPort;
+import io.wisoft.avocadobackendhexagonal.domain.hospital.domain.Hospital;
+import io.wisoft.avocadobackendhexagonal.domain.staff.domain.Staff;
+import io.wisoft.avocadobackendhexagonal.global.exception.notfound.CustomNotFoundException;
+import io.wisoft.avocadobackendhexagonal.settings.common.ServiceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class LoadStaffServiceTest extends ServiceTest {
+
+    @Autowired
+    private SignUpService signUpService;
+    @Autowired
+    private SaveHospitalPort saveHospitalPort;
+    @Autowired
+    private LoadStaffService loadStaffService;
+
+    @Test
+    @DisplayName("의료진 단건 조회 성공 테스트")
+    public void loadStaff_success() throws Exception {
+        //given -- 조건
+        //병원 생성 및 저장
+        final Hospital hospital = getHospital();
+        final Long savedHospitalId = saveHospitalPort.save(hospital);
+
+        //의료진 가입 및 저장
+        final var signupStaffCommand = getSignupStaffCommand(savedHospitalId);
+        final Long savedStaffId = signUpService.signupStaff(signupStaffCommand);
+
+        //when -- 동작
+        final Staff findStaff = loadStaffService.loadStaff(savedStaffId);
+
+        //then -- 검증
+        assertThat(findStaff).isNotNull();
+        assertThat(findStaff.getEmail()).isEqualTo(signupStaffCommand.email());
+    }
+
+
+    @Test
+    @DisplayName("의료진 단건 조회 실패 테스트")
+    public void loadStaff_fail() throws Exception {
+        //given -- 조건
+        //병원 생성 및 저장
+        final Hospital hospital = getHospital();
+        final Long savedHospitalId = saveHospitalPort.save(hospital);
+
+        //의료진 가입 및 저장
+        final var signupStaffCommand = getSignupStaffCommand(savedHospitalId);
+        signUpService.signupStaff(signupStaffCommand);
+
+        //when -- 동작
+        //then -- 검증
+        assertThrows(CustomNotFoundException.class, () -> {
+
+            //존재하지 않는 id로 조회
+            final Staff findStaff = loadStaffService.loadStaff(10000L);
+        });
+    }
+
+
+    @Test
+    @DisplayName("의료진 목록 조회 성공 테스트")
+    public void loadStaffList_success() throws Exception {
+        //given -- 조건
+        //병원 생성 및 저장
+        final Hospital hospital = getHospital();
+        final Long savedHospitalId = saveHospitalPort.save(hospital);
+
+        //30명의 의료진 저장
+        IntStream.range(0, 30)
+                .mapToObj(i -> signUpService.signupStaff(
+                        new SignupStaffCommand(
+                                "name " + i,
+                                "email " + i,
+                                "password " + i,
+                                "license " + i,
+                                "DENTAL",
+                                savedHospitalId
+                        )))
+                .toList();
+
+        //when -- 동작
+        final List<Staff> staffList = loadStaffService.loadStaffList();
+
+        //then -- 검증
+        assertThat(staffList.size()).isEqualTo(30);
+    }
+
+
+    private Hospital getHospital() {
+        return Hospital.registerHospital(
+                null,
+                "name",
+                "number",
+                "address",
+                "oper"
+        );
+    }
+
+    private SignupStaffCommand getSignupStaffCommand(final Long savedHospitalId) {
+        return new SignupStaffCommand(
+                "name",
+                "email",
+                "password",
+                "license",
+                "DENTAL",
+                savedHospitalId
+        );
+    }
+}

--- a/src/test/java/io/wisoft/avocadobackendhexagonal/domain/staff/application/service/UpdateStaffServiceTest.java
+++ b/src/test/java/io/wisoft/avocadobackendhexagonal/domain/staff/application/service/UpdateStaffServiceTest.java
@@ -1,0 +1,67 @@
+package io.wisoft.avocadobackendhexagonal.domain.staff.application.service;
+
+import io.wisoft.avocadobackendhexagonal.domain.auth.application.port.in.command.SignupStaffCommand;
+import io.wisoft.avocadobackendhexagonal.domain.auth.application.service.SignUpService;
+import io.wisoft.avocadobackendhexagonal.domain.hospital.application.port.out.SaveHospitalPort;
+import io.wisoft.avocadobackendhexagonal.domain.hospital.domain.Hospital;
+import io.wisoft.avocadobackendhexagonal.domain.staff.application.port.in.command.UpdateStaffPasswordCommand;
+import io.wisoft.avocadobackendhexagonal.domain.staff.application.port.out.LoadStaffPort;
+import io.wisoft.avocadobackendhexagonal.domain.staff.domain.Staff;
+import io.wisoft.avocadobackendhexagonal.settings.common.ServiceTest;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mindrot.jbcrypt.BCrypt;
+import org.springframework.beans.factory.annotation.Autowired;
+
+
+class UpdateStaffServiceTest extends ServiceTest {
+
+    @Autowired private SignUpService signUpService;
+    @Autowired private SaveHospitalPort saveHospitalPort;
+    @Autowired private LoadStaffPort loadStaffPort;
+    @Autowired private UpdateStaffService updateStaffService;
+
+    @Test
+    public void validatePassword_success() throws Exception {
+        //given -- 조건
+        //병원 생성 및 저장
+        final Hospital hospital = getHospital();
+        final Long savedHospitalId = saveHospitalPort.save(hospital);
+
+        //의료진 가입 및 저장
+        final var signupStaffCommand = getSignupStaffCommand(savedHospitalId);
+        final Long savedStaffId = signUpService.signupStaff(signupStaffCommand);
+
+        //비밀번호 세팅
+        final String newPassword = "newPassword";
+        final var updateStaffPasswordCommand = new UpdateStaffPasswordCommand(signupStaffCommand.password(), newPassword);
+
+        //when -- 동작
+        final Long updatedStaffId = updateStaffService.updatePassword(savedStaffId, updateStaffPasswordCommand);
+
+        //then -- 검증
+        final Staff findStaff = loadStaffPort.findById(updatedStaffId);
+        Assertions.assertThat(BCrypt.checkpw(newPassword, findStaff.getPassword())).isTrue();
+    }
+
+    private SignupStaffCommand getSignupStaffCommand(final Long savedHospitalId) {
+        return new SignupStaffCommand(
+                "name",
+                "email",
+                "password",
+                "license",
+                "DENTAL",
+                savedHospitalId
+        );
+    }
+
+    private Hospital getHospital() {
+        return Hospital.registerHospital(
+                null,
+                "name",
+                "number",
+                "address",
+                "oper"
+        );
+    }
+}

--- a/src/test/java/io/wisoft/avocadobackendhexagonal/domain/staff/domain/StaffTest.java
+++ b/src/test/java/io/wisoft/avocadobackendhexagonal/domain/staff/domain/StaffTest.java
@@ -1,5 +1,8 @@
 package io.wisoft.avocadobackendhexagonal.domain.staff.domain;
 
+import io.wisoft.avocadobackendhexagonal.domain.hospital.domain.Hospital;
+import io.wisoft.avocadobackendhexagonal.global.enumeration.HospitalDept;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class StaffTest {
@@ -7,16 +10,69 @@ class StaffTest {
     @Test
     public void updateHospital() throws Exception {
         //given -- 조건
-        final Staff staff = Staff.createStaff(
+        final Staff staff = getStaff();
+
+        //when -- 동작
+        staff.updateHospital(
+                Hospital.registerHospital(
+                        2L,
+                        "updateName",
+                        "updateNumber",
+                        "updateAddress",
+                        "operatingTime"
+                )
+        );
+
+        //then -- 검증
+        Assertions.assertThat(staff.getHospital().getId()).isEqualTo(2L);
+        Assertions.assertThat(staff.getHospital().getName()).isEqualTo("updateName");
+        Assertions.assertThat(staff.getHospital().getNumber()).isEqualTo("updateNumber");
+        Assertions.assertThat(staff.getHospital().getAddress()).isEqualTo("updateAddress");
+        Assertions.assertThat(staff.getHospital().getOperatingTime()).isEqualTo("operatingTime");
+    }
+
+
+    @Test
+    public void updatePhotoPath() throws Exception {
+        //given -- 조건
+        final Staff staff = getStaff();
+
+        //when -- 동작
+        staff.updatePhotoPath("newPhotoPath");
+
+        //then -- 검증
+        Assertions.assertThat(staff.getStaffPhotoPath()).isEqualTo("newPhotoPath");
+    }
+
+
+    @Test
+    public void updatePassword() throws Exception {
+        //given -- 조건
+        final Staff staff = getStaff();
+
+        //when -- 동작
+        staff.updatePassword("newPassword");
+
+        //then -- 검증
+        Assertions.assertThat(staff.getPassword()).isEqualTo("newPassword");
+    }
+
+    private Staff getStaff() {
+        return Staff.createStaff(
                 1L,
                 "name",
                 "email",
-
+                "password",
+                "license",
+                "photo",
+                HospitalDept.DENTAL,
+                Hospital.registerHospital(
+                        1L,
+                        "hospName",
+                        "number",
+                        "address",
+                        "oper"
                 )
-
-        //when -- 동작
-
-        //then -- 검증
+        );
     }
-
 }

--- a/src/test/java/io/wisoft/avocadobackendhexagonal/domain/staff/domain/StaffTest.java
+++ b/src/test/java/io/wisoft/avocadobackendhexagonal/domain/staff/domain/StaffTest.java
@@ -1,0 +1,22 @@
+package io.wisoft.avocadobackendhexagonal.domain.staff.domain;
+
+import org.junit.jupiter.api.Test;
+
+class StaffTest {
+
+    @Test
+    public void updateHospital() throws Exception {
+        //given -- 조건
+        final Staff staff = Staff.createStaff(
+                1L,
+                "name",
+                "email",
+
+                )
+
+        //when -- 동작
+
+        //then -- 검증
+    }
+
+}

--- a/src/test/java/io/wisoft/avocadobackendhexagonal/settings/common/ControllerTest.java
+++ b/src/test/java/io/wisoft/avocadobackendhexagonal/settings/common/ControllerTest.java
@@ -1,0 +1,9 @@
+package io.wisoft.avocadobackendhexagonal.settings.common;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+public class ControllerTest {
+}

--- a/src/test/java/io/wisoft/avocadobackendhexagonal/settings/common/PersistenceAdapterTest.java
+++ b/src/test/java/io/wisoft/avocadobackendhexagonal/settings/common/PersistenceAdapterTest.java
@@ -1,0 +1,7 @@
+package io.wisoft.avocadobackendhexagonal.settings.common;
+
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+public class PersistenceAdapterTest {
+}

--- a/src/test/java/io/wisoft/avocadobackendhexagonal/settings/common/ServiceTest.java
+++ b/src/test/java/io/wisoft/avocadobackendhexagonal/settings/common/ServiceTest.java
@@ -1,0 +1,9 @@
+package io.wisoft.avocadobackendhexagonal.settings.common;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Transactional
+public class ServiceTest {
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,16 @@
+spring:
+  profiles:
+    include: db, jwt, redis
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.orm.jdbc.bind: trace
+    org.springframework.core.LocalVariableTableParameterNameDiscoverer: error


### PR DESCRIPTION
## What is this PR? 📍
의료진 관련 기능의 테스트 코드를 작성합니다.

[기존 프로젝트](https://github.com/HBNU-Avocado/Avocado-backend)에서는 Controller 테스트를 [Rest-assured](https://rest-assured.io/)로 작성했지만, 
해당 리팩토링 프로젝트에서는 [MockMvc](https://spring.io/guides/gs/testing-web/)를 이용해 테스트를 작성해 나갈 예정입니다.

현재 작성한 테스트의 종류는 아래와 같습니다.
- 통합 테스트 : 컨트롤러, 서비스, 영속성 어댑터
- 단위 테스트 : 도메인

<br/>

서비스의 경우 단위 테스트로 작성해야 적합할 것 같아, 추후 학습을 한 뒤 재작성할 예정입니다.

<br/>

## Changes 🔍
1. 비밀번호 변경시 암호화 과정이 누락되어 있어, 이를 추가하였습니다.
2. 테스트 코드 작성 중 발견한 오류사항들을 수정하였습니다.
  2-1. HospitalEntity를 삭제할 경우, `@OneToMany` 관계인 의료진도 함께 삭제되도록 `CascadeType.REMOVE`로 설정
  2-2. 의료진 비밀번호 수정 요청시 사용되는 DTO에 누락된 비밀번호 정규 패턴 검사를 추가
  2-3. 비밀번호 변경시 encryptHelper를 호출하는 과정에서 매개변수를 반대로 넘겨주는 오류를 수정

<br/>
 
## Todo 🗓️
- [ ] 서비스 테스트를 단위테스트로 다시 작성해보기

<br/>